### PR TITLE
Add SQLAlchemy persistence

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 gunicorn
+Flask-SQLAlchemy


### PR DESCRIPTION
## Summary
- integrate Flask-SQLAlchemy
- create `Job` model and auto-create DB
- persist new jobs to the database
- query jobs from DB for dashboard
- update requirements with Flask-SQLAlchemy

## Testing
- `python3 -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_b_68844efba84083238c60340f613161a6