### PR TITLE
Add user auth and role-based access

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,59 +1,123 @@
-from flask import Flask, render_template, redirect, url_for, request, session, flash
-from functools import wraps
+from flask import Flask, render_template, redirect, url_for, request, flash
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager, UserMixin, login_user, login_required, \
+    logout_user, current_user
+from werkzeug.security import generate_password_hash, check_password_hash
 
 app = Flask(__name__)
 app.secret_key = 'supersecretkey'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///app.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
-USERS = {"admin": "password123"}
-JOBS = []
+db = SQLAlchemy(app)
+login_manager = LoginManager(app)
+login_manager.login_view = 'login'
 
-def login_required(f):
-    @wraps(f)
-    def decorated(*args, **kwargs):
-        if 'username' not in session:
-            flash("Login required.")
-            return redirect(url_for('login'))
-        return f(*args, **kwargs)
-    return decorated
+
+class User(UserMixin, db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    role = db.Column(db.String(20), nullable=False, default='tech')
+
+    def set_password(self, password: str) -> None:
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password: str) -> bool:
+        return check_password_hash(self.password_hash, password)
+
+
+class Job(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    site = db.Column(db.String(120))
+    date = db.Column(db.String(50))
+    tech = db.Column(db.String(80))
+    status = db.Column(db.String(50))
+
+
+@login_manager.user_loader
+def load_user(user_id: str):
+    return User.query.get(int(user_id))
+
 
 @app.route('/')
 def home():
     return redirect(url_for('dashboard'))
 
+
 @app.route('/login', methods=['GET', 'POST'])
 def login():
     if request.method == 'POST':
-        u = request.form['username']
-        p = request.form['password']
-        if USERS.get(u) == p:
-            session['username'] = u
+        user = User.query.filter_by(username=request.form['username']).first()
+        if user and user.check_password(request.form['password']):
+            login_user(user)
             return redirect(url_for('dashboard'))
-        flash("Wrong credentials")
+        flash('Wrong credentials')
     return render_template('login.html')
 
+
 @app.route('/logout')
+@login_required
 def logout():
-    session.clear()
+    logout_user()
     return redirect(url_for('login'))
+
 
 @app.route('/dashboard')
 @login_required
 def dashboard():
-    return render_template('dashboard.html', jobs=JOBS)
+    if current_user.role == 'tech':
+        jobs = Job.query.filter_by(tech=current_user.username).all()
+    else:
+        jobs = Job.query.all()
+    return render_template('dashboard.html', jobs=jobs)
+
 
 @app.route('/add-job', methods=['GET', 'POST'])
 @login_required
 def add_job():
     if request.method == 'POST':
-        JOBS.append({
-            'site': request.form['site'],
-            'date': request.form['date'],
-            'tech': request.form['tech'],
-            'status': request.form['status']
-        })
+        job = Job(
+            site=request.form['site'],
+            date=request.form['date'],
+            tech=request.form['tech'],
+            status=request.form['status'],
+        )
+        db.session.add(job)
+        db.session.commit()
         return redirect(url_for('dashboard'))
     return render_template('add_job.html')
 
+
+@app.route('/register', methods=['GET', 'POST'])
+@login_required
+def register():
+    if current_user.role != 'admin':
+        flash('Admin access required.')
+        return redirect(url_for('dashboard'))
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        role = request.form.get('role', 'tech') or 'tech'
+        if User.query.filter_by(username=username).first():
+            flash('Username already exists.')
+        else:
+            user = User(username=username, role=role)
+            user.set_password(password)
+            db.session.add(user)
+            db.session.commit()
+            flash('User registered.')
+            return redirect(url_for('dashboard'))
+    return render_template('register.html')
+
+
 if __name__ == '__main__':
-    print("Flask app is starting...")
-    app.run(debug=True, host="0.0.0.0", port=5050)
+    with app.app_context():
+        db.create_all()
+        if not User.query.filter_by(username='admin').first():
+            admin = User(username='admin', role='admin')
+            admin.set_password('password123')
+            db.session.add(admin)
+            db.session.commit()
+    print('Flask app is starting...')
+    app.run(debug=True, host='0.0.0.0', port=5050)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 Flask
+Flask-SQLAlchemy
+Flask-Login
 gunicorn

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,8 +4,16 @@
   <title>Field Service App</title>
 </head>
 <body>
-  {% if session.username %}
-    <p>Logged in as {{ session.username }} | <a href="{{ url_for('dashboard') }}">Dashboard</a> | <a href="{{ url_for('logout') }}">Logout</a></p>
+  {% if current_user.is_authenticated %}
+    <p>
+      Logged in as {{ current_user.username }} |
+      <a href="{{ url_for('dashboard') }}">Dashboard</a> |
+      <a href="{{ url_for('add_job') }}">Add Job</a> |
+      {% if current_user.role == 'admin' %}
+        <a href="{{ url_for('register') }}">Register User</a> |
+      {% endif %}
+      <a href="{{ url_for('logout') }}">Logout</a>
+    </p>
   {% endif %}
   <hr>
   {% with messages = get_flashed_messages() %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% block content %}
+<div style="font-family: sans-serif; max-width: 400px; margin: auto;">
+  <h1 style="text-align:center;">Register User</h1>
+  <form method="post">
+    <div style="margin-bottom:10px;">
+      <label>Username:</label><br>
+      <input name="username" type="text" required style="width:100%;">
+    </div>
+    <div style="margin-bottom:10px;">
+      <label>Password:</label><br>
+      <input name="password" type="password" required style="width:100%;">
+    </div>
+    <div style="margin-bottom:10px;">
+      <label>Role:</label><br>
+      <select name="role" style="width:100%;">
+        <option value="tech" selected>tech</option>
+        <option value="admin">admin</option>
+      </select>
+    </div>
+    <div style="text-align:center;">
+      <input type="submit" value="Register" style="padding:8px 16px;">
+    </div>
+  </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add SQLAlchemy and Flask-Login dependencies
- implement User and Job models
- create registration route for admins
- filter dashboard jobs based on user role
- show navigation options for admins
- add user registration form

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_688453c96170832394a92655776d5339